### PR TITLE
fix: Apply zizmor recommendations

### DIFF
--- a/.github/actions/setup-cog/action.yaml
+++ b/.github/actions/setup-cog/action.yaml
@@ -5,15 +5,22 @@ inputs:
     description: "Cog version to install"
     required: true
     default: "0.0.26"
+outputs:
+  bin-path:
+    description: "Path to the cog binary"
+    value: ${{ steps.setup.outputs.bin-path }}
 runs:
   using: "composite"
   steps:
     - name: Download cog
       shell: bash
+      env:
+        COG_VERSION: ${{ inputs.version }}
       run: |
+        version="$(echo "${COG_VERSION}" | sed 's/[^a-zA-Z0-9._\/-]//g')"
         mkdir -p "${HOME}/.local/bin/"
-        wget https://github.com/grafana/cog/releases/download/v${{ inputs.version }}/cog_Linux_x86_64.tar.gz
+        wget "https://github.com/grafana/cog/releases/download/v${version}/cog_Linux_x86_64.tar.gz"
         tar -xzf cog_Linux_x86_64.tar.gz
         mv cog "${HOME}/.local/bin/cog"
         chmod +x "${HOME}/.local/bin/cog"
-        echo "${HOME}/.local/bin" >> $GITHUB_PATH
+        echo "bin-path=${HOME}/.local/bin" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,8 +8,7 @@ env:
 
 permissions:
   contents: read
-  # to comment on PRs
-  pull-requests: write
+  pull-requests: read
 
 defaults:
   run:
@@ -22,6 +21,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Setup cog
         uses: ./.github/actions/setup-cog
@@ -30,13 +31,19 @@ jobs:
         run: |
           cog inspect --config .cog/config.yaml \
             --ir builders
+        env:
+          PATH: ${{ steps.setup-cog.outputs.bin-path }}:${{ env.PATH }}
 
   diff_preview:
     name: Generate diff
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Setup cog
         uses: ./.github/actions/setup-cog
@@ -61,12 +68,14 @@ jobs:
           CLEANUP_WORKSPACE: 'no'
           LOG_LEVEL: '7' # debug
           GOGC: 'off'
+          PATH: ${{ steps.setup-cog.outputs.bin-path }}:${{ env.PATH }}
 
       - name: Checkout main branch
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
         with:
           ref: main
           path: promql-builder-main
+          persist-credentials: false
 
       - name: Preview diff
         run: |
@@ -104,7 +113,7 @@ jobs:
           EOF
 
       - name: Find preview comment
-        uses: peter-evans/find-comment@v3
+        uses: peter-evans/find-comment@a0b5124c1959e5e7c25efa20d957d507d54a6f4e  #v3.1.0
         id: preview-comment-find
         # only run on main repo, and not on dependabot PRs
         if: "!contains(github.actor, 'dependabot') && github.repository == 'grafana/promql-builder'"
@@ -114,7 +123,7 @@ jobs:
           body-includes: 'promql-builder-diff-preview-marker'
 
       - name: Upsert preview comment
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@17c956346987a35d40d2d723c6930f90f594400d #v4.0.0
         # only run on main repo, and not on dependabot PRs
         if: "!contains(github.actor, 'dependabot') && github.repository == 'grafana/promql-builder'"
         with:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -23,6 +23,10 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write      # to deploy to Pages
+      id-token: write   # to verify the deployment originates from an appropriate source
 
     # Deploy to the github-pages environment
     environment:
@@ -31,6 +35,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Install devbox
         uses: jetify-com/devbox-install-action@a03caf5813591bc882139eba6ae947930a83a427 #v0.11.0
@@ -50,9 +56,11 @@ jobs:
 
   deploy:
     needs: build
-
     name: Publish
     runs-on: ubuntu-latest
+    permissions:
+      pages: write      # to deploy to Pages
+      id-token: write   # to verify the deployment originates from an appropriate source
 
     environment:
       name: github-pages

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,12 +20,9 @@ on:
 env:
   DEVBOX_VERSION: '0.13.1'
 
-# Grant GITHUB_TOKEN the permissions required to make a release
+# Default permissions
 permissions:
-  contents: write # to push new branches
-  actions: write # new branches will contain github actions
-  pages: write      # to deploy to Pages
-  id-token: write   # to verify the deployment originates from an appropriate source
+  contents: read
 
 # Allow only one concurrent release, skipping runs queued between the run in-progress and latest queued.
 # However, do NOT cancel in-progress runs as we want to allow these releases to complete.
@@ -44,6 +41,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Setup cog
         uses: ./.github/actions/setup-cog
@@ -67,12 +66,16 @@ jobs:
           DRY_RUN: ${{ inputs.dryRun == true && 'yes' || 'no' }}
           SKIP_VALIDATION: ${{ inputs.skipValidation == true && 'yes' || 'no' }}
           VERSION: ${{ inputs.version }}
+          PATH: ${{ steps.setup-cog.outputs.bin-path }}:${{ env.PATH }}
 
   build_docs:
     needs: codegen
-
     name: Build documentation
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write      # to deploy to Pages
+      id-token: write   # to verify the deployment originates from an appropriate source
 
     # Deploy to the github-pages environment
     environment:
@@ -83,6 +86,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
         with:
           ref: main # to ensure that we build docs using the results of the codegen job
+          persist-credentials: false
 
       - name: Install devbox
         uses: jetify-com/devbox-install-action@a03caf5813591bc882139eba6ae947930a83a427 #v0.11.0
@@ -103,9 +107,11 @@ jobs:
 
   publish_documentation:
     needs: build_docs
-
     name: Publish documentation
     runs-on: ubuntu-latest
+    permissions:
+      pages: write      # to deploy to Pages
+      id-token: write   # to verify the deployment originates from an appropriate source
 
     if: ${{ ! inputs.dryRun }}
 
@@ -120,10 +126,8 @@ jobs:
 
   release_python:
     needs: codegen
-
     name: Release Python package
     runs-on: ubuntu-latest
-
     permissions:
       contents: read
       id-token: write  # mandatory for trusted publishing
@@ -136,6 +140,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
         with:
           ref: main # to ensure that we use the latest and greatest
+          persist-credentials: false
 
       - name: Install devbox
         uses: jetify-com/devbox-install-action@a03caf5813591bc882139eba6ae947930a83a427 #v0.11.0
@@ -148,17 +153,15 @@ jobs:
 
       - name: Publish distribution 📦 to PyPI
         if: ${{ ! inputs.dryRun }}
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc #v1.12.4
         with:
           packages-dir: python/dist/
           attestations: false
 
   release_typescript:
     needs: codegen
-
     name: Release Typescript package
     runs-on: ubuntu-latest
-
     permissions:
       contents: read
       id-token: write
@@ -174,6 +177,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
         with:
           ref: main # to ensure that we use the latest and greatest
+          persist-credentials: false
 
       - name: Use Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v4


### PR DESCRIPTION
**Changes in this PR**
- Applies the recommendations from [zizmor](https://woodruffw.github.io/zizmor/) to improve CI security
- Fixes:
  - [x] `input.version` may expand into attacker-controllable code
  - [x] resolves writing to `GITHUB_PATH` as recommended [here](https://woodruffw.github.io/zizmor/audits/#remediation_12) using `GITHUB_OUTPUT` instead
  - [x] sets `persist-credentials: false`
  - [x] `pull-requests: write` overly broad at workflow level
  - [x] action versions not pinned to a hash

**Reference**
- https://grafana.com/blog/2025/04/27/grafana-security-update-no-customer-impact-from-github-workflow-vulnerability/