### PR TITLE
Fix binary expression rendering when group modifiers are involved

### DIFF
--- a/.cog/templates/python/overrides/object_promql_BinaryExpr_custom_methods.py.tmpl
+++ b/.cog/templates/python/overrides/object_promql_BinaryExpr_custom_methods.py.tmpl
@@ -16,6 +16,8 @@ def __str__(self):
 
         if self.group_labels is not None and len(self.group_labels) != 0:
             buffer += "(" + ", ".join(self.group_labels) + ") "
+        else:
+            buffer += "() "
 
     buffer += "(" + str(self.right) + ")"
 


### PR DESCRIPTION
Parentheses that follow a `group_left` or `group_right` can be ambiguous when they surround the right side of the binary expression and when no argument is passed to the group modifier.

This fix explicitely renders empty parentheses for group modifiers that have no label list.