### PR TITLE
Fix binary expression rendering when group modifiers are involved

### DIFF
--- a/go/promql/types_gen.go
+++ b/go/promql/types_gen.go
@@ -453,11 +453,11 @@ func (expr BinaryExpr) String() string {
 			buffer.WriteString("group_right")
 		}
 
+		buffer.WriteString("(")
 		if len(expr.GroupLabels) != 0 {
-			buffer.WriteString("(")
 			buffer.WriteString(strings.Join(expr.GroupLabels, ", "))
-			buffer.WriteString(") ")
 		}
+		buffer.WriteString(") ")
 	}
 
 	buffer.WriteString("(")

--- a/typescript/src/promql/types.gen.ts
+++ b/typescript/src/promql/types.gen.ts
@@ -274,6 +274,8 @@ const binaryExprToString = (expr: BinaryExpr): string => {
 
         if (expr.groupLabels && expr.groupLabels.length !== 0) {
             buffer += `(${expr.groupLabels.join(', ')}) `;
+        } else {
+            buffer += '() ';
         }
     }
 


### PR DESCRIPTION
Parentheses that follow a `group_left` or `group_right` can be ambiguous when they surround the right side of the binary expression and when no argument is passed to the group modifier.

This fix explicitely renders empty parentheses for group modifiers that have no label list.

Same as edf5d3ce8ddc577cfd949a7ec67b008a3f8d0f54, which was for Python. This commit is the same fix for Go and Typescript.