### PR TITLE
Always render parenthesis for GroupLabels expressions

### DIFF
--- a/.cog/templates/go/overrides/object_promql_BinaryExpr_custom_methods.go.tmpl
+++ b/.cog/templates/go/overrides/object_promql_BinaryExpr_custom_methods.go.tmpl
@@ -34,11 +34,11 @@ func (expr BinaryExpr) String() string {
             buffer.WriteString("group_right")
         }
 
+        buffer.WriteString("(")
         if len(expr.GroupLabels) != 0 {
-            buffer.WriteString("(")
             buffer.WriteString(strings.Join(expr.GroupLabels, ", "))
-            buffer.WriteString(") ")
         }
+        buffer.WriteString(") ")
     }
 
     buffer.WriteString("(")

--- a/.cog/templates/typescript/overrides/object_promql_BinaryExpr_custom_methods.ts.tmpl
+++ b/.cog/templates/typescript/overrides/object_promql_BinaryExpr_custom_methods.ts.tmpl
@@ -18,6 +18,8 @@ const binaryExprToString = (expr: BinaryExpr): string => {
 
         if (expr.groupLabels && expr.groupLabels.length !== 0) {
             buffer += `(${expr.groupLabels.join(', ')}) `;
+        } else {
+            buffer += `() `;
         }
     }
 


### PR DESCRIPTION
Replaces https://github.com/grafana/promql-builder/pull/11 that modifies generated files instead of the source templates.