### PR TITLE
Fix release pipeline

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -190,11 +190,11 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
-        run: node ci
+        run: npm install
 
       - name: Build
-        run: node build
+        run: npm run build
 
       - name: Publish to NPM registry
         if: ${{ ! inputs.dryRun }}
-        run: node publish --access public
+        run: npm publish

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -39,6 +39,9 @@ jobs:
     name: Run codegen and release
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: write # the codegen pipeline commits + creates a tag + pushes back to origin
+
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+build==1.5.0
 mypy==2.1.0
 mypy-extensions==1.1.0
 zensical==0.0.43


### PR DESCRIPTION
This PR addresses a few issues I spotted with the release pipeline:

* the codegen job needs `contents: write` permissions to push a tag and a commit
* a python dependency was missing
* the commands used to build and publish the NPM package were incorrect