### PR TITLE
Let the release pipeline open PRs

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,6 +28,7 @@ jobs:
 
     permissions:
       contents: write # the codegen pipeline commits + creates a tag + pushes back to origin
+      pull-requests: write # to open PRs
 
     outputs:
       is_release: ${{ steps.release.outputs.is_release }}


### PR DESCRIPTION
This permission needs to be set to let the release pipeline do its job and open PRs.