### PR TITLE
Make sure the NPM is up-to-date when releasing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,8 +15,8 @@ defaults:
     shell: bash
 
 jobs:
-  validate_cog_config:
-    name: Validate cog config
+  run_codegen:
+    name: Run codegen pipeline
     runs-on: ubuntu-latest
 
     steps:
@@ -24,9 +24,24 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Validate cog's config
+      - name: Install devbox
+        uses: jetify-com/devbox-install-action@8c6a66ed6273138b1915457069de78cb52fe3bd7 # v0.15.0
+        with:
+          enable-cache: 'true'
+          devbox-version: ${{ env.DEVBOX_VERSION }}
+
+      - name: Run codegen pipeline
         run: |
-          make validate-config
+          git config --global user.email "cog-ci@grafana.com"
+          git config --global user.name "cog - CI"
+
+          make prepare-release
+        env:
+          TERM: 'xterm'
+          WORKSPACE_PATH: /tmp/promql-builder-current
+          LOG_LEVEL: '7' # debug
+          GOGC: 'off'
+          SKIP_VALIDATION: 'no'
 
   diff_preview:
     name: Generate diff

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,6 +59,7 @@ jobs:
           CLEANUP_WORKSPACE: 'no'
           LOG_LEVEL: '7' # debug
           GOGC: 'off'
+          SKIP_VALIDATION: 'yes'
 
       - name: Identify latest branch
         id: latest_branch

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -193,6 +193,9 @@ jobs:
           scope: '@grafana'
           registry-url: 'https://registry.npmjs.org'
 
+      - name: Update NPM
+        run: npm install -g npm@latest
+
       - name: Install dependencies
         run: npm install
 


### PR DESCRIPTION
The typescript release failed with this error:

```
npm notice
npm notice Publishing to https://registry.npmjs.org/ with tag latest and public access
npm notice publish Signed provenance statement with source and build information from GitHub Actions
npm notice publish Provenance statement published to transparency log: https://search.sigstore.dev/?logIndex=1656620383
npm error code E404
npm error 404 Not Found - PUT https://registry.npmjs.org/@grafana%2fpromql-builder - Not found
npm error 404
npm error 404  '@grafana/promql-builder@0.0.5' is not in this registry.
npm error 404
npm error 404 Note that you can also install from a
npm error 404 tarball, folder, http url, or git url.
```

From what I could find online, people with this issue resolved it by updating NPM in their pipeline :shrug: 

Anyway, can't hurt to have an up-to-date NPM when releasing a package.

**Drive-by change:** run the codegen pipeline in the CI, instead of just validating its config.